### PR TITLE
Fix modifier one name for 2525D land units

### DIFF
--- a/JSON/2525D 10 land-unit.json
+++ b/JSON/2525D 10 land-unit.json
@@ -1282,7 +1282,7 @@
   "modifier 1": [
     { "modifier": "Unspecified", "category": "", "code": "00", "remarks": "" },
     {
-      "modifier": "Tactical Satellite Communications",
+      "modifier": "Air Mobile/Air Assault",
       "category": "Capability",
       "code": "01",
       "remarks": ""


### PR DESCRIPTION
According to MILSTD2525D the name of the "01" modifier for land units
should be "Air Mobile/Air Assault", "not Tactical Satellite Communications".